### PR TITLE
add authentication to members page

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,10 @@
+export default function ({ store, redirect, error }) {
+  // If user not connected, redirect to /
+  if (!store.state.authUser) {
+  //   return redirect('/')
+    error({
+      message: 'You are not connected',
+      statusCode: 403
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
+    "serve": "npm run build && cross-env NODE_ENV=production node server.js",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint"
   },

--- a/pages/members.vue
+++ b/pages/members.vue
@@ -1,7 +1,16 @@
 <template>
-  <div class="container">
+  <form v-if="!$store.state.authUser" @submit.prevent="login">
+    <h1>This page is for C4 members only. Please login to continue.</h1>
+    <p class="error" v-if="formError">{{ formError }}</p>
+    <p>Username: <input type="text" v-model="formUsername" name="username" /></p>
+    <p>Password: <input type="password" v-model="formPassword" name="password" /></p>
+    <button type="submit">Login</button>
+    <p><e>Not a member? <nuxt-link to="/">Click here to go back home.</nuxt-link></e></p>
+  </form>
+  <div v-else class="container">
     <div>
       <v-header/>
+      <button @click="logout">Logout</button>
       <h1 class="title">
         C4 Ministry
       </h1>
@@ -185,6 +194,33 @@ export default {
   components: {
     'v-header': Header,
     'v-footer': Footer
+  },
+  data () {
+    return {
+      formError: null,
+      formUsername: '',
+      formPassword: ''
+    }
+  },
+  methods: {
+    login () {
+      this.$store.dispatch('login', {
+        username: this.formUsername,
+        password: this.formPassword
+      })
+      .then(() => {
+        this.formUsername = ''
+        this.formPassword = ''
+        this.formError = null
+      })
+      .catch((e) => {
+        this.formError = e.message
+      })
+    },
+    logout () {
+      this.$store.dispatch('logout')
+      this.$router.push('/')
+    }
   }
 }
 </script>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+const Nuxt = require('nuxt')
+const bodyParser = require('body-parser')
+const session = require('express-session')
+const app = require('express')()
+
+// Body parser, to access req.body
+app.use(bodyParser.json())
+
+// Sessions to create req.session
+app.use(session({
+  secret: 'super-secret-key',
+  resave: false,
+  saveUninitialized: false,
+  cookie: { maxAge: 60000 }
+}))
+
+// POST /api/login to log in the user and add him to the req.session.authUser
+app.post('/api/login', function (req, res) {
+  if (req.body.username === 'c4member' && req.body.password === 'c4trinity') {
+    req.session.authUser = { username: req.body.username }
+    return res.json({ username: req.body.username })
+  }
+  res.status(401).json({ error: 'Incorrect username or password. Please try again.' })
+})
+
+// POST /api/logout to log out the user and remove it from the req.session
+app.post('/api/logout', function (req, res) {
+  delete req.session.authUser
+  res.json({ ok: true })
+})
+
+// We instantiate Nuxt.js with the options
+const isProd = process.env.NODE_ENV === 'production'
+const nuxt = new Nuxt({ dev: !isProd })
+// No build in production
+const promise = (isProd ? Promise.resolve() : nuxt.build())
+promise.then(() => {
+  app.use(nuxt.render)
+  app.listen(3000)
+  console.log('Server is listening on http://localhost:3000')
+})
+.catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+export const state = () => ({
+  authUser: null
+})
+
+export const mutations = {
+  SET_USER: function (state, user) {
+    state.authUser = user
+  }
+}
+
+export const actions = {
+  nuxtServerInit ({ commit }, { req }) {
+    if (req.session && req.session.authUser) {
+      commit('SET_USER', req.session.authUser)
+    }
+  },
+  login ({ commit }, { username, password }) {
+    return axios.post('/api/login', {
+      username,
+      password
+    })
+    .then((res) => {
+      commit('SET_USER', res.data)
+    })
+    .catch((error) => {
+      if (error.response.status === 401) {
+        throw new Error('Incorrect username or password')
+      }
+    })
+  },
+
+  logout ({ commit }) {
+    return axios.post('/api/logout')
+    .then(() => {
+      commit('SET_USER', null)
+    })
+  }
+
+}


### PR DESCRIPTION
I added authentication to the members page using Nuxt Auth Routes. Right now the username and password are hardcoded in server.js but we should definitely serialize it/encode it later. 

The members page will now either render the login form (if user is not logged in) or members page (if the user is logged in). The login persists even if you refresh the page or if you go to home page or other places on the site (let me know if you don't want it to persist). The user can log out on the members page. 

I added a "serve" script so that I didn't have to run two commands every time I made changes: "build" and "node server.js".  